### PR TITLE
Stable1.4 CVE 2022-34903

### DIFF
--- a/g10/status.c
+++ b/g10/status.c
@@ -305,17 +305,14 @@ write_status_text_and_buffer ( int no, const char *string,
             }
             first = 0;
         }
-        for (esc=0, s=buffer, n=len; n && !esc; s++, n-- ) {
+        for (esc=0, s=buffer, n=len; n; s++, n-- ) {
             if ( *s == '%' || *(const byte*)s <= lower_limit
                            || *(const byte*)s == 127 )
                 esc = 1;
-            if ( wrap && ++count > wrap ) {
+            if ( wrap && ++count > wrap )
                 dowrap=1;
+            if (esc || dowrap)
                 break;
-            }
-        }
-        if (esc) {
-            s--; n++;
         }
         if (s != buffer)
             fwrite (buffer, s-buffer, 1, statusfp );


### PR DESCRIPTION
This is a backport of upstream commit 34c649b3601383cd11dbc76221747ec16fd68e1b

Depending on the escaping and line wrapping the computed remaining
buffer length could be wrong.  Fixed by always using a break to
terminate the escape detection loop.  Might have happened for all
status lines which may wrap.

GnuPG-bug-id: T6027

Also see:

https://marc.info/?l=oss-security&m=165657063921408&w=2

Signed-off-by: Brian C. Lane <bcl@redhat.com>